### PR TITLE
Add File System

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -190,7 +190,7 @@ func (fs *FS) read(dec decoder) []any {
 		return []any{err.Error()}
 	}
 
-	return []any{nil, n, string(b)}
+	return []any{nil, n, b}
 }
 
 func (fs *FS) readdir(dec decoder) []any {

--- a/fs.go
+++ b/fs.go
@@ -1,0 +1,482 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"syscall"
+)
+
+type FS struct {
+}
+
+type decoder func(v any) ([]any, bool)
+
+var ErrUimplemented = errors.New("operation is unimplemented")
+
+// TODO: handle offset and position.
+func (fs *FS) write(dec decoder) []any {
+	var r struct {
+		FD     int `json:"fd"`
+		Buffer string
+
+		// options ignored: offset, length and position.
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	// forward the write syscall.
+	n, err := syscall.Write(r.FD, []byte(r.Buffer))
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	// return the bytes written.
+	return []any{nil, n}
+}
+
+func (fs *FS) chmod(dec decoder) []any {
+	var r struct {
+		Path string
+		Mode uint32
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	// forward the chmod syscall.
+	err := os.Chmod(r.Path, os.FileMode(r.Mode))
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil}
+}
+
+func (fs *FS) chown(dec decoder) []any {
+	var r struct {
+		Path string
+		UID  int `json:"uid"`
+		GID  int `json:"gid"`
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	// forward the chown syscall.
+	err := os.Chown(r.Path, r.UID, r.GID)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil}
+}
+
+func (fs *FS) close(dec decoder) []any {
+	var r struct {
+		FD int `json:"fd"`
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	// forward the close syscall.
+	err := syscall.Close(r.FD)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil}
+}
+
+func (fs *FS) fchmod(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) fchown(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) ftruncate(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) lchown(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) link(dec decoder) []any {
+	var r struct {
+		Path string
+		Link string
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	// forward the link syscall.
+	err := syscall.Link(r.Path, r.Link)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil}
+}
+
+func (fs *FS) lstat(dec decoder) []any {
+	var r struct {
+		Path string
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	var s syscall.Stat_t
+
+	err := syscall.Lstat(r.Path, &s)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil, convertStat(s)}
+}
+
+func (fs *FS) mkdir(dec decoder) []any {
+	var r struct {
+		Path string
+		Perm uint32
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	err := syscall.Mkdir(r.Path, r.Perm)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil}
+}
+
+func (fs *FS) read(dec decoder) []any {
+	var r struct {
+		FD     int `json:"fd"`
+		Length int
+
+		// options ignored: buffer, offset and position.
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	// create a slice with the amount of bytes we want to read.
+	b := make([]byte, r.Length)
+
+	// forward the read syscall.
+	n, err := syscall.Read(r.FD, b)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil, n, string(b)}
+}
+
+func (fs *FS) readdir(dec decoder) []any {
+	var r struct {
+		Path string
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	files, err := os.ReadDir(r.Path)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	var ns []string
+
+	// collect the file names.
+	for _, f := range files {
+		ns = append(ns, f.Name())
+	}
+
+	return []any{nil, ns}
+}
+
+func (fs *FS) readlink(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) rename(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) rmdir(dec decoder) []any {
+	var r struct {
+		Path string
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	err := syscall.Rmdir(r.Path)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil}
+}
+
+func (fs *FS) stat(dec decoder) []any {
+	var r struct {
+		Path string
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	var s syscall.Stat_t
+
+	err := syscall.Stat(r.Path, &s)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil, convertStat(s)}
+}
+
+func (fs *FS) symlink(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) truncate(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) utimes(dec decoder) []any {
+	return []any{ErrUimplemented.Error()}
+}
+
+func (fs *FS) open(dec decoder) []any {
+	var r struct {
+		Path  string
+		Flags int
+		Perm  uint32
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	fd, err := syscall.Open(r.Path, r.Flags, r.Perm)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil, fd}
+}
+
+func (fs *FS) fstat(dec decoder) []any {
+	var r struct {
+		FD int `json:"fd"`
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	var s syscall.Stat_t
+
+	err := syscall.Fstat(r.FD, &s)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil, convertStat(s)}
+}
+
+func (fs *FS) unlink(dec decoder) []any {
+	var r struct {
+		Path string
+	}
+
+	if msg, ok := dec(&r); !ok {
+		return msg
+	}
+
+	err := syscall.Unlink(r.Path)
+	if err != nil {
+		return []any{err.Error()}
+	}
+
+	return []any{nil}
+}
+
+func (fs *FS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.URL.Path, "/fs/")
+	if op == "" {
+		http.Error(w, "operation is required", http.StatusBadRequest)
+		return
+	}
+
+	dec := func(v any) ([]any, bool) {
+		err := json.NewDecoder(r.Body).Decode(v)
+		if err != nil {
+			http.Error(w, "failed to decode body", http.StatusBadRequest)
+			return []any{err.Error()}, false
+		}
+
+		return nil, true
+	}
+
+	var res []any
+
+	switch op {
+	case "write":
+		res = fs.write(dec)
+
+	case "chmod":
+		res = fs.chmod(dec)
+
+	case "chown":
+		res = fs.chown(dec)
+
+	case "close":
+		res = fs.close(dec)
+
+	case "fchmod":
+		res = fs.fchmod(dec)
+
+	case "fchown":
+		res = fs.fchown(dec)
+
+	case "fstat":
+		res = fs.fstat(dec)
+
+	case "ftruncate":
+		res = fs.ftruncate(dec)
+
+	case "lchown":
+		res = fs.lchown(dec)
+
+	case "link":
+		res = fs.link(dec)
+
+	case "lstat":
+		res = fs.lstat(dec)
+
+	case "mkdir":
+		res = fs.mkdir(dec)
+
+	case "open":
+		res = fs.open(dec)
+
+	case "read":
+		res = fs.read(dec)
+
+	case "readdir":
+		res = fs.readdir(dec)
+
+	case "readlink":
+		res = fs.readlink(dec)
+
+	case "rename":
+		res = fs.rename(dec)
+
+	case "rmdir":
+		res = fs.rmdir(dec)
+
+	case "stat":
+		res = fs.stat(dec)
+
+	case "symlink":
+		res = fs.symlink(dec)
+
+	case "truncate":
+		res = fs.truncate(dec)
+
+	case "utimes":
+		res = fs.utimes(dec)
+
+	case "unlink":
+		res = fs.unlink(dec)
+
+	default:
+		http.Error(w, fmt.Sprintf("unhandled operation: %s", op), http.StatusBadRequest)
+		return
+	}
+
+	err := json.NewEncoder(w).Encode(res)
+	if err != nil {
+		http.Error(w, "failed to write body", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("content-type", "application/json")
+}
+
+type JSStat struct {
+	// same as `*os.Stat`.
+	Dev     int32  `json:"dev"`
+	Ino     uint64 `json:"ino"`
+	Mode    uint16 `json:"mode"`
+	Nlink   uint16 `json:"nlink"`
+	Uid     uint32 `json:"uid"`
+	Gid     uint32 `json:"gid"`
+	Rdev    int32  `json:"rdev"`
+	Size    int64  `json:"size"`
+	Blksize int32  `json:"blksize"`
+	Blocks  int64  `json:"blocks"`
+
+	// specific to `fs.Stat`.
+	AtimeMs int64 `json:"atimeMs"`
+	MtimeMs int64 `json:"mtimeMs"`
+	CtimeMs int64 `json:"ctimeMs"`
+
+	// wether not the file is a directory. used for `isDirectory()`.
+	Dir bool `json:"dir"`
+}
+
+func convertStat(s syscall.Stat_t) JSStat {
+	// create a fs-compatible stat.
+	// https://github.com/golang/go/blob/1cc19e5ba0a008df7baeb78e076e43f9d8e0abf2/src/syscall/fs_js.go#L165
+	st := JSStat{
+		Dev:     s.Dev,
+		Ino:     s.Ino,
+		Mode:    s.Mode,
+		Nlink:   s.Nlink,
+		Uid:     s.Uid,
+		Gid:     s.Gid,
+		Rdev:    s.Rdev,
+		Size:    s.Size,
+		Blksize: s.Blksize,
+		Blocks:  s.Blocks,
+	}
+
+	st.AtimeMs = s.Atimespec.Sec * 1000
+	st.MtimeMs = s.Mtimespec.Sec * 1000
+	st.CtimeMs = s.Ctimespec.Sec * 1000
+
+	// https://github.com/golang/go/blob/50034e9faac531e0e4d6cbf4d172462ca23c9be2/src/os/stat_darwin.go#L12-L42.
+	if s.Mode&syscall.S_IFMT == syscall.S_IFDIR {
+		st.Dir = true
+	}
+
+	return st
+}

--- a/fs_test.go
+++ b/fs_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// run a the forwarded file system tests.
+func TestFS(t *testing.T) {
+	build(t)
+
+	// ensure we remove any test related files.
+	t.Cleanup(func() {
+		fs, err := filepath.Glob("testdata/*.test*")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, f := range fs {
+			os.RemoveAll(f)
+		}
+	})
+
+	run(t,
+		"go",
+		"test",
+		"-exec",
+		"../wasmexec",
+		"-v",
+		"--run",
+		"TestFS",
+		// forward the UID and GID for testing chown, since we can't use environment variables.
+		"--args",
+		fmt.Sprintf("uid=%d", os.Getuid()),
+		fmt.Sprintf("gid=%d", os.Getgid()),
+	)
+}

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 					error.code = "EFAULT";
 
 					callback(error);
+					return;
 				}
 
 				callback(...result);

--- a/index.html
+++ b/index.html
@@ -130,8 +130,13 @@
 						return callback(args[0]);
 					}
 
-					// encode the value.
-					const value = encoder.encode(args[2]);
+					// decode the value.
+					const value = Uint8Array.from(
+						// []byte is always encoded in base64.
+						atob(args[2]),
+						// https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem.
+						(c) => c.codePointAt(0)
+					);
 
 					// update the buffer.
 					buffer.set(value);

--- a/index.html
+++ b/index.html
@@ -2,6 +2,179 @@
 <script>
 	// fetch wasm exec.
 	import("/wasm_exec.js").then(async () => {
+		{{if .FS}}
+		const FS = async (method, options) => {
+			const response = await fetch(`/fs/${method}`, {
+				headers: {
+					"content-type": "application/json",
+					"accept": "application/json"
+				},
+				method: "POST",
+				body: JSON.stringify(options)
+			});
+
+			if (!response.ok) {
+				throw new Error(`failed to make file system request: ${await response.text()}`);
+			}
+
+			return await response.json();
+		}
+
+		const forward = (method, options, callback) => {
+			FS(method, options).then((result) => {
+				if (result[0]) {
+					const error = new Error(result[0]);
+					// we need a code otherwise we'll panic. falling back to "fault" here.
+					// https://github.com/golang/go/blob/8da6405e0db80fa0a4136fb816c7ca2db716c2b2/src/syscall/fs_js.go#L563.
+					error.code = "EFAULT";
+
+					callback(error);
+				}
+
+				callback(...result);
+			});
+		}
+
+		const write = globalThis.fs.write.bind(globalThis.fs);
+
+		let outputBuf = "";
+
+		const encoder = new TextEncoder("utf-8");
+		const decoder = new TextDecoder("utf-8");
+
+		globalThis.fs = {
+			constants: {
+				O_WRONLY: {{.Flags.O_WRONLY}},
+				O_RDWR: {{.Flags.O_RDWR}},
+				O_CREAT: {{.Flags.O_CREAT}},
+				O_TRUNC: {{.Flags.O_TRUNC}},
+				O_APPEND: {{.Flags.O_APPEND}},
+				O_EXCL: {{.Flags.O_EXCL}}
+			},
+			writeSync(fd, buf) {
+				outputBuf += decoder.decode(buf);
+				const nl = outputBuf.lastIndexOf("\n");
+				if (nl != -1) {
+					console.log(outputBuf.substring(0, nl));
+					outputBuf = outputBuf.substring(nl + 1);
+				}
+				return buf.length;
+			},
+			write(fd, buffer, offset, length, position, callback) {
+				if (offset !== 0 || length !== buffer.length || position !== null) {
+					callback(enosys());
+					return;
+				}
+
+				if (fd < 3) {
+					write(fd, buffer, offset, length, position, callback);
+					return;
+				}
+
+				// decode the buffer, easier to work with as a string.
+				const decoded = decoder.decode(buffer);
+
+				forward("write", { fd, buffer: decoded, offset, length, position }, callback);
+			},
+			chmod(path, mode, callback) {
+				forward("chmod", { path, mode }, callback);
+			},
+			chown(path, uid, gid, callback) {
+				forward("chown", { path, uid, gid }, callback);
+			},
+			close(fd, callback) {
+				forward("close", { fd }, callback);
+			},
+			fchmod(fd, mode, callback) {
+				forward("fchmod", { fd, mode }, callback);
+			},
+			fchown(fd, uid, gid, callback) {
+				forward("fchown", { fd, uid, gid }, callback);
+			},
+			fstat(fd, callback) {
+				forward("fstat", { fd }, (...args) => {
+					if (args[0]) {
+						return callback(args[0]);
+					}
+
+					args[1].isDirectory = () => args[1].dir;
+
+					callback(...args);
+				});
+			},
+			fsync(fd, callback) {
+				callback(null);
+			},
+			ftruncate(fd, length, callback) {
+				forward("ftruncate", { fd, length }, callback);
+			},
+			lchown(path, uid, gid, callback) {
+				forward("lchown", { path, uid, gid }, callback);
+			},
+			link(path, link, callback) {
+				forward("link", { path, link }, callback);
+			},
+			lstat(path, callback) {
+				forward("lstat", { path }, callback);
+			},
+			mkdir(path, perm, callback) {
+				forward("mkdir", { path, perm }, callback);
+			},
+			open(path, flags, perm, callback) {
+				forward("open", { path, flags, perm }, callback);
+			},
+			read(fd, buffer, offset, length, position, callback) {
+				forward("read", { fd, buffer, offset, length, position }, (...args) => {
+					if (args[0]) {
+						return callback(args[0]);
+					}
+
+					// encode the value.
+					const value = encoder.encode(args[2]);
+
+					// update the buffer.
+					buffer.set(value);
+
+					// set the returned value to the buffer.
+					args[2] = buffer;
+
+					return callback(...args);
+				});
+			},
+			readdir(path, callback) {
+				forward("readdir", { path }, callback);
+			},
+			readlink(path, callback) {
+				forward("readlink", { path }, callback);
+			},
+			rename(from, to, callback) {
+				forward("rename", { from, to }, callback);
+			},
+			rmdir(path, callback) {
+				forward("rmdir", { path }, callback);
+			},
+			stat(path, callback) {
+				forward("stat", { path }, callback);
+			},
+			symlink(path, link, callback) {
+				forward("symlink", { path, link }, callback);
+			},
+			truncate(path, length, callback) {
+				forward("truncate", { path, length }, callback);
+			},
+			unlink(path, callback) {
+				forward("unlink", { path }, callback);
+			},
+			utimes(path, atime, mtime, callback) {
+				forward("utimes", { path, atime, mtime }, callback);
+			}
+		};
+
+		globalThis.process.cwd = () => {
+			return {{.CWD}};
+		}
+		{{end}}
+
 		// create a new program.
 		const go = new Go();
 
@@ -14,6 +187,7 @@
 		// execute the program.
 		await go.run(instance);
 
+		// signal the program has exited.
 		console.log("wasmexec:exit");
 	});
 </script>

--- a/main_test.go
+++ b/main_test.go
@@ -52,7 +52,7 @@ func run(t *testing.T, name string, args ...string) {
 func TestTest(t *testing.T) {
 	build(t)
 
-	run(t, "go", "test", "-exec", "../wasmexec", "-v")
+	run(t, "go", "test", "-exec", "../wasmexec", "-v", "--run", "TestUserAgent")
 }
 
 // run a test with wasmexec as the executor.

--- a/testdata/fs_test.go
+++ b/testdata/fs_test.go
@@ -1,0 +1,219 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// find arguments passed to the test via --args and remove --test flags.
+func findArgs() []string {
+	var args []string
+
+	for _, arg := range os.Args {
+		// skip any args starting with test.
+		if strings.HasPrefix(arg, "-test.") {
+			continue
+		}
+
+		// add a dash so we parse the argument as a flag.
+		args = append(args, "-"+arg)
+	}
+
+	return args
+}
+
+// TODO: expand from smoke test, test functionality (i.e. chmod changes the permissions).
+func TestFS(t *testing.T) {
+	var uid int
+	var gid int
+
+	// create a new flag set for test specific flags.
+	fset := flag.NewFlagSet("", flag.PanicOnError)
+	fset.IntVar(&uid, "uid", 0, "")
+	fset.IntVar(&gid, "gid", 0, "")
+
+	// parse the flags.
+	err := fset.Parse(findArgs())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		Name string
+		Test func(t *testing.T, f *os.File, n string)
+		Dir  bool
+	}{
+		{
+			Name: "open",
+			Test: func(t *testing.T, f *os.File, n string) {},
+		},
+		{
+			Name: "close",
+			Test: func(t *testing.T, f *os.File, n string) {
+				err = f.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name: "write",
+			Test: func(t *testing.T, f *os.File, n string) {
+				_, err = f.Write([]byte("Hello World"))
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name: "read",
+			Test: func(t *testing.T, f *os.File, n string) {
+				// populate the file.
+				f.Write([]byte("Hello World"))
+
+				// close the file, so changes are written to disk.
+				f.Close()
+
+				// reopen the file.
+				f, err = os.Open(n)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// try to read "Hello"
+				b := make([]byte, 5)
+
+				// read from the file.
+				_, err = f.Read(b)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// ensure the value matches.
+				if !bytes.Equal(b, []byte("Hello")) {
+					t.Fatalf("expected \"Hello\" but got \"%s\"", b)
+				}
+			},
+		},
+		{
+			Name: "chmod",
+			Test: func(t *testing.T, f *os.File, n string) {
+				err := os.Chmod(n, 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name: "chown",
+			Test: func(t *testing.T, f *os.File, n string) {
+				err := os.Chown(n, uid, gid)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name: "stat",
+			Test: func(t *testing.T, f *os.File, n string) {
+				_, err := os.Stat(n)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Name: "link",
+			Test: func(t *testing.T, f *os.File, n string) {
+				err := os.Link(n, n+".2")
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			Dir:  true,
+			Name: "mkdir",
+			Test: func(t *testing.T, f *os.File, n string) {},
+		},
+		{
+			Dir:  true,
+			Name: "readdir",
+			Test: func(t *testing.T, f *os.File, n string) {
+				// create 5 files.
+				for i := 0; i < 5; i++ {
+					// create the file. name formated demo_{index}.txt.
+					f, err := os.Create(filepath.Join(n, fmt.Sprintf("demo_%d.txt", i)))
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					// close the file.
+					f.Close()
+				}
+
+				// read the directory.
+				dir, err := os.ReadDir(n)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// ensure the file count matches.
+				if len(dir) != 5 {
+					t.Fatalf("expected 5 files but got %d", len(dir))
+				}
+			},
+		},
+		{
+			Dir:  true,
+			Name: "rmdir",
+			Test: func(t *testing.T, f *os.File, n string) {
+				err := os.Remove(n)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			if test.Dir {
+				// format the directory name {name}.test.
+				n := fmt.Sprintf("%s.test", test.Name)
+
+				// create the directory.
+				err := os.Mkdir(n, 0777)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// execute the test.
+				test.Test(t, nil, n)
+				return
+			}
+
+			// format the file name {name}.test.txt.
+			n := fmt.Sprintf("%s.test.txt", test.Name)
+
+			// create a file.
+			f, err := os.Create(n)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// ensure the file closes.
+			defer f.Close()
+
+			// execute the test.
+			test.Test(t, f, n)
+		})
+	}
+}


### PR DESCRIPTION
this PR adds a syscall forwarding system so we can make file system calls from the browser.

operations implemented:
- [x] write
- [x] chmod
- [x] chown
- [x] close
- [ ] fchmod
- [ ] fchown
- [x] fstat
- [ ] ftruncate
- [ ] lchown
- [x] link
- [x] lstat
- [x] mkdir
- [x] open
- [x] read
- [x] readdir
- [ ] readlink
- [ ] rename
- [x] rmdir
- [x] stat
- [ ] symlink
- [ ] truncate
- [ ] utimes
- [x] unlink